### PR TITLE
Update oauth2 dependency

### DIFF
--- a/lib/ueberauth/strategy/microsoft.ex
+++ b/lib/ueberauth/strategy/microsoft.ex
@@ -1,8 +1,8 @@
 defmodule Ueberauth.Strategy.Microsoft do
   use Ueberauth.Strategy, default_scope: "https://graph.microsoft.com/user.read openid email offline_access",
                           uid_field: :id
-                      
-  alias OAuth2.{Response, Error, AccessToken}
+
+  alias OAuth2.{Response, Error}
   alias Ueberauth.Auth.{Info, Credentials, Extra}
   alias Ueberauth.Strategy.Microsoft.OAuth
 
@@ -12,7 +12,7 @@ defmodule Ueberauth.Strategy.Microsoft do
   def handle_request!(conn) do
     default_scopes = option(conn, :default_scope)
     extra_scopes = option(conn, :extra_scopes)
-    
+
     scopes = "#{extra_scopes} #{default_scopes}"
 
     authorize_url =
@@ -31,22 +31,23 @@ defmodule Ueberauth.Strategy.Microsoft do
   def handle_callback!(%Plug.Conn{params: %{"code" => code}} = conn) do
     opts = [redirect_uri: callback_url(conn)]
     client = OAuth.get_token!([code: code], opts)
-    
-    case client.access_token do
+    token = client.token
+
+    case token.access_token do
       nil ->
-        err = client.other_params["error"]
-        desc = client.other_params["error_description"]
+        err = token.other_params["error"]
+        desc = token.other_params["error_description"]
         set_errors!(conn, [error(err, desc)])
       _token ->
         fetch_user(conn, client)
     end
   end
-  
+
   @doc false
   def handle_callback!(conn) do
     set_errors!(conn, [error("missing_code", "No code received")])
   end
-  
+
   @doc false
   def handle_cleanup!(conn) do
     conn
@@ -95,11 +96,11 @@ defmodule Ueberauth.Strategy.Microsoft do
     }
   end
 
-  defp fetch_user(conn, token) do
-    conn = put_private(conn, :ms_token, token)
+  defp fetch_user(conn, client) do
+    conn = put_private(conn, :ms_token, client.token)
     path = "https://graph.microsoft.com/v1.0/me/"
 
-    case AccessToken.get(token, path, [], UeberauthMicrosoft.default_http_opts) do
+    case OAuth2.Client.get(client, path) do
       {:ok, %Response{status_code: 401}} ->
         set_errors!(conn, [error("token", "unauthorized")])
       {:ok, %Response{status_code: 200, body: response}} ->
@@ -108,7 +109,7 @@ defmodule Ueberauth.Strategy.Microsoft do
         set_errors!(conn, [error("OAuth2", reason)])
     end
   end
-  
+
   defp option(conn, key) do
     default = Keyword.get(default_options(), key)
 

--- a/lib/ueberauth/strategy/microsoft/oauth.ex
+++ b/lib/ueberauth/strategy/microsoft/oauth.ex
@@ -8,7 +8,8 @@ defmodule Ueberauth.Strategy.Microsoft.OAuth do
     strategy: __MODULE__,
     site: "https://graph.microsoft.com",
     authorize_url: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
-    token_url: "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+    token_url: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+    request_opts: [ssl_options: [versions: [:'tlsv1.2']]]
   ]
 
   def client(opts \\ []) do

--- a/lib/ueberauth/strategy/microsoft/oauth.ex
+++ b/lib/ueberauth/strategy/microsoft/oauth.ex
@@ -23,16 +23,17 @@ defmodule Ueberauth.Strategy.Microsoft.OAuth do
 
   def authorize_url!(params \\ [], opts \\ []) do
     opts
-      |> client()
+      |> client
       |> Client.authorize_url!(params)
   end
 
   def get_token!(params \\ [], opts \\ []) do
     opts
-      |> client()
-      |> put_param(:client_secret, client().client_secret)
-      |> Client.get_token!(params, [], opts ++ UeberauthMicrosoft.default_http_opts)
+      |> client
+      |> Client.get_token!(params)
   end
+
+  # oauth2 Strategy Callbacks
 
   def authorize_url(client, params) do
     AuthCode.authorize_url(client, params)
@@ -40,6 +41,7 @@ defmodule Ueberauth.Strategy.Microsoft.OAuth do
 
   def get_token(client, params, headers) do
     client
+      |> put_param(:client_secret, client.client_secret)
       |> put_header("Accept", "application/json")
       |> AuthCode.get_token(params, headers)
   end

--- a/lib/ueberauth_microsoft.ex
+++ b/lib/ueberauth_microsoft.ex
@@ -1,5 +1,3 @@
 defmodule UeberauthMicrosoft do
   @moduledoc false
-
-  def default_http_opts, do: [hackney: [ssl_options: [versions: [:'tlsv1.2']]]]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule UeberauthMicrosoft.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:oauth2, "0.6.0"},
+      {:oauth2, "~> 0.8"},
       {:ueberauth, "~> 0.4"},
       {:ex_doc, ">= 0.14.0", only: :dev}
     ]


### PR DESCRIPTION
This PR updates the oauth2 dependency to ~>0.8 to stop conflict with other oauth2-based ueberauth strategies using oauth2 versions >=0.7 (Google, Facebook, etc), as there is a non-backwards compatible API change at this version.