### PR TITLE
Microsoft seems to lazily initialize certain aspects of user records.…

### DIFF
--- a/lib/ueberauth/strategy/microsoft.ex
+++ b/lib/ueberauth/strategy/microsoft.ex
@@ -103,8 +103,8 @@ defmodule Ueberauth.Strategy.Microsoft do
     case OAuth2.Client.get(client, path) do
       {:ok, %Response{status_code: 401}} ->
         set_errors!(conn, [error("token", "unauthorized")])
-      {:ok, %Response{status_code: 200, body: response}} ->
-          put_private(conn, :ms_user, response)
+      {:ok, %Response{status_code: status, body: response}} when status in 200..299 ->
+        put_private(conn, :ms_user, response)
       {:error, %Error{reason: reason}} ->
         set_errors!(conn, [error("OAuth2", reason)])
     end


### PR DESCRIPTION
The first time `fetch_user` is called referencing a newly created ms account, the
resulting response body will mirror that of the documented response found on
Microsoft's site, but the status code will be 202 instead of 200. This change
adds support for that (apparently undocumented) case.