### PR TITLE
Allow configuration options to be passed dynamically

### DIFF
--- a/lib/ueberauth/strategy/microsoft.ex
+++ b/lib/ueberauth/strategy/microsoft.ex
@@ -20,7 +20,7 @@ defmodule Ueberauth.Strategy.Microsoft do
       conn.params
       |> Map.put(:scope, scopes)
       |> Map.put(:redirect_uri, callback_url(conn))
-      |> OAuth.authorize_url!()
+      |> OAuth.authorize_url!(options(conn))
 
     redirect!(conn, authorize_url)
   end
@@ -29,7 +29,7 @@ defmodule Ueberauth.Strategy.Microsoft do
   Handles the callback from Microsoft.
   """
   def handle_callback!(%Plug.Conn{params: %{"code" => code}} = conn) do
-    opts = [redirect_uri: callback_url(conn)]
+    opts = conn |> options() |> Keyword.put(:redirect_uri, callback_url(conn))
     client = OAuth.get_token!([code: code], opts)
     token = client.token
 


### PR DESCRIPTION
Hello and thanks for creating this package.

In my app I need to dynamically lookup the oauth details, and supply them to ueberauth through the [Ueberauth.run_request](https://hexdocs.pm/ueberauth/Ueberauth.html#run_request/4) and [Ueberauth.run_callback](https://hexdocs.pm/ueberauth/Ueberauth.html#run_callback/4) functions.

The changes in the PR forward the options provided down to the calls into the `OAuth` module, where they take precedence over the ones in the app config.