### PR TITLE
Handle Oauth token error in handle_callback

### DIFF
--- a/lib/ueberauth/strategy/microsoft.ex
+++ b/lib/ueberauth/strategy/microsoft.ex
@@ -42,6 +42,9 @@ defmodule Ueberauth.Strategy.Microsoft do
       _token ->
         fetch_user(conn, client)
     end
+  rescue
+    err in [Error] ->
+      set_errors!(conn, [error("OAuth2", err.reason)])
   end
 
   @doc false


### PR DESCRIPTION
Sometimes we are receiving the following error when our users try to login using their Microsoft account:

```
** (OAuth2.Error) :timeout
```

The backtrace points to the `handle_callback!/1` call which, in turn calls `OAuth2.Client.get_token!`. When the OAuth2 call fails, the `handle_callback!/1` function does not handle the error.

This pull request simply handles the OAuth2.Error and adds the error into the connection just like it was done in 848f074270b098facad90f11e66d5e43bc1556ee. The `ueberauth_google` library also [handles this errors in a similar way](https://github.com/ueberauth/ueberauth_google/blob/ea1e292e0993d336d64687180e159889dfeca7c5/lib/ueberauth/strategy/google.ex#L151-L152).