### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,14 @@
 # The directory Mix will write compiled artifacts to.
-/_build
+/_build/
 
 # If you run "mix test --cover", coverage assets end up here.
-/cover
+/cover/
 
 # The directory Mix downloads your dependencies sources to.
-/deps
+/deps/
 
-# Where 3rd-party dependencies like ExDoc output generated docs.
-/doc
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
 
 # Ignore .fetch files in case you like to edit your project deps locally.
 /.fetch
@@ -19,8 +19,11 @@ erl_crash.dump
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
 
-#vscode files
-.vscode
+# Ignore package tarball (built via "mix hex.build").
+ueberauth_microsoft-*.tar
 
-# ignore elixir language server files
-/.elixir_ls
+# Temporary files, for example, from tests.
+/tmp/
+
+# VSCode files.
+.vscode


### PR DESCRIPTION
Follows the latest .gitignore generated by latest Elixir `mix new`
template.