### PR TITLE
Fix: extra scopes is not merged with existing scopes

### DIFF
--- a/lib/ueberauth/strategy/microsoft.ex
+++ b/lib/ueberauth/strategy/microsoft.ex
@@ -15,7 +15,7 @@ defmodule Ueberauth.Strategy.Microsoft do
 
     params =
       [scope: scopes]
-      |> with_optional(:extra_scopes, conn)
+      |> with_scopes(:extra_scopes, conn)
       |> with_state_param(conn)
 
     opts = oauth_client_options_from_conn(conn)
@@ -117,8 +117,10 @@ defmodule Ueberauth.Strategy.Microsoft do
     end
   end
 
-  defp with_optional(opts, key, conn) do
-    if option(conn, key), do: Keyword.put(opts, key, option(conn, key)), else: opts
+  defp with_scopes(opts, key, conn) do
+    if option(conn, key),
+      do: Keyword.put(opts, :scope, "#{Keyword.get(opts, :scope, "")} #{option(conn, key)}"),
+      else: opts
   end
 
   defp oauth_client_options_from_conn(conn) do

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule UeberauthMicrosoft.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/swelham/ueberauth_microsoft"
-  @version "0.13.0"
+  @version "0.13.1"
 
   def project do
     [


### PR DESCRIPTION
- `extra_scopes` from options was put in parameters using `extra_scopes` as key,
rather than appending to default scopes.
- Bump patch version