### PR TITLE
patch/improvement: Added `optional` function and ability to pass `prompt` so that one may select the account to authenticate with.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,15 @@ config :ueberauth, Ueberauth,
   ]
 ```
 
+If you would like users to have the option to choose an alternate account to authenticate with instead of defaulting to the logged in account, you may pass the `prompt` option in to the provider (per [Microsoft documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow)):
+
+```elixir
+config :ueberauth, Ueberauth,
+  providers: [
+    microsoft: {Ueberauth.Strategy.Microsoft, [prompt: "select_account"]}
+  ]
+```
+
 ## Copyright and License
 
 Copyright (c) 2017 Stuart Welham

--- a/lib/ueberauth/strategy/microsoft.ex
+++ b/lib/ueberauth/strategy/microsoft.ex
@@ -16,6 +16,7 @@ defmodule Ueberauth.Strategy.Microsoft do
     params =
       [scope: scopes]
       |> with_scopes(:extra_scopes, conn)
+      |> with_optional(:prompt, conn)
       |> with_state_param(conn)
 
     opts = oauth_client_options_from_conn(conn)
@@ -115,6 +116,10 @@ defmodule Ueberauth.Strategy.Microsoft do
       {:error, %Error{reason: reason}} ->
         set_errors!(conn, [error("OAuth2", reason)])
     end
+  end
+
+  defp with_optional(opts, key, conn) do
+    if option(conn, key), do: Keyword.put(opts, key, option(conn, key)), else: opts
   end
 
   defp with_scopes(opts, key, conn) do


### PR DESCRIPTION
The code I have added is identical to the Google strategy: https://github.com/ueberauth/ueberauth_google/blob/master/lib/ueberauth/strategy/google.ex

One should have the option to allow users to choose the account to authenticate with. See:
https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow