### PR TITLE
Parse scopes to match Ueberauth typespec

### DIFF
--- a/lib/ueberauth/strategy/microsoft.ex
+++ b/lib/ueberauth/strategy/microsoft.ex
@@ -68,11 +68,13 @@ defmodule Ueberauth.Strategy.Microsoft do
 
   def credentials(conn) do
     token = conn.private.ms_token
+    scope_string = token.other_params["scope"] || ""
+    scopes = String.split(scope_string, " ", trim: true)
 
     %Credentials{
       expires: token.expires_at != nil,
       expires_at: token.expires_at,
-      scopes: token.other_params["scope"],
+      scopes: scopes,
       token: token.access_token,
       refresh_token: token.refresh_token,
       token_type: token.token_type


### PR DESCRIPTION
[Ueberauth.Auth.Credentials](https://github.com/ueberauth/ueberauth/blob/master/lib/ueberauth/auth/credentials.ex) typespec indicates that `Credentials.scopes` should be a list of strings. This change brings this strategy in line with the behavior of other strategies e.g. [Google](https://github.com/ueberauth/ueberauth_google/blob/master/lib/ueberauth/strategy/google.ex#L83).

NB this is a breaking change for any current users of this library which should be noted in the changelog.