### PR TITLE
Allow dynamic configs

### DIFF
--- a/lib/ueberauth/strategy/microsoft.ex
+++ b/lib/ueberauth/strategy/microsoft.ex
@@ -134,10 +134,20 @@ defmodule Ueberauth.Strategy.Microsoft do
     base_options = [redirect_uri: callback_url(conn)]
     request_options = conn.private[:ueberauth_request_options].options
 
-    case {request_options[:client_id], request_options[:client_secret]} do
-      {nil, _} -> base_options
-      {_, nil} -> base_options
-      {id, secret} -> [client_id: id, client_secret: secret] ++ base_options
+    request_options =
+      Keyword.take(request_options, [
+        :tenant_id,
+        :client_id,
+        :client_secret,
+        :authorize_url,
+        :token_url,
+        :request_opts
+      ])
+
+    if nil in Keyword.values(request_options) do
+      base_options
+    else
+      request_options ++ base_options
     end
   end
 


### PR DESCRIPTION
Hey @swelham, 

I propose the following PR to allow `UeberauthMicrosoft` to be used with multi-tenant applications (where a single Microsoft config won't be sufficient; i.e. applications that let users to login via their own Microsoft accounts). 

It somehow relates to this comment [here](https://github.com/ueberauth/ueberauth/issues/106#issuecomment-618062131) and this one [here](https://github.com/ueberauth/ueberauth/issues/106#issuecomment-631787288).

Basically what I'm doing is passing a bunch of options from the `conn` all the way down to the `Oauth.client/1` function. This way, I can do the following in my own app controller:

```elixir
  def request(conn, %{"provider" => "microsoft", "key" => key}) do
    config = get_config_for_key(key)
    config = Application.fetch_env!(:ueberauth, Ueberauth.Strategy.Microsoft.OAuth)[key]

    {
      Ueberauth.Strategy.Microsoft,
      [
        tenant_id: config[:tenant_id],
        client_id: config[:client_id],
        client_secret: config[:client_secret],
        callback_path: "/auth/microsoft/callback/#{key}",
        site: "https://graph.microsoft.com",
        authorize_url:
          "https://login.microsoftonline.com/#{config[:tenant_id]}/oauth2/v2.0/authorize",
        token_url: "https://login.microsoftonline.com/#{config[:tenant_id]}/oauth2/v2.0/token",
        request_opts: [ssl_options: [versions: [:"tlsv1.2"]]]
      ]
    }
  end
```

You can see here that I select the proper Microsoft credentials based on some path params.
Let me know what you think. Happy to discuss a different approach. 