### PR TITLE
Config can be loaded dynamically

### DIFF
--- a/lib/ueberauth/strategy/microsoft/oauth.ex
+++ b/lib/ueberauth/strategy/microsoft/oauth.ex
@@ -6,7 +6,7 @@ defmodule Ueberauth.Strategy.Microsoft.OAuth do
   alias OAuth2.Strategy.AuthCode
 
   def client(opts \\ []) do
-    config = Application.get_env(:ueberauth, __MODULE__)
+    config = Application.get_env(:ueberauth, __MODULE__, [])
     json_library = Ueberauth.json_library()
 
     config


### PR DESCRIPTION
## Motivation

This strategy cannot be loaded dynamically [as the documentation specifies](https://github.com/ueberauth/ueberauth/blob/3d55a21a30e718d0ddd9a1ea529dfc999c321b5c/lib/ueberauth.ex#L294), see the lower snippet.

``` elixir
# From Ueberauth/lib/ueberauth.ex doc

# Request authentication against a provider.

# specified dynamically in arguments. For example, you can specify in a
# controller:

      def request(conn, %{"provider_name" => provider_name} = _params) do
        provider_config = case provider_name do
          "github" ->
            { Ueberauth.Strategy.Github, [
              default_scope: "user",
              request_path:  provider_auth_path(conn, :request, provider_name),
              callback_path: provider_auth_path(conn, :callback, provider_name),
            ]}
        end
        conn
        |> Ueberauth.run_request(provider_name, provider_config)
      end
```

## Current behaviour

The request phase is stucked during the loading in the `OAuth` module in the Keyword merging in `client/1`.
## Fix

Like the Google Ueberauth strategy, the fix is quiet easy :


```
# lib / Ueberauth / strategy / microsoft / oauth.ex line 9

    config = Application.get_env(:ueberauth, __MODULE__, [])
```
