### PR TITLE
Add the option to get the client secret dynamically.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,30 +1,10 @@
-# This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
-# This configuration is loaded before any dependency and is restricted
-# to this project. If another project depends on this project, this
-# file won't be loaded nor affect the parent project. For this reason,
-# if you want to provide default values for your application for
-# 3rd-party users, it should be done in your "mix.exs" file.
+config :ueberauth, Ueberauth,
+  providers: [
+    microsoft: {Ueberauth.Strategy.Microsoft, []}
+  ]
 
-# You can configure for your application as:
-#
-#     config :ueberauth_microsoft, key: :value
-#
-# And access this configuration in your application as:
-#
-#     Application.get_env(:ueberauth_microsoft, :key)
-#
-# Or configure a 3rd-party app:
-#
-#     config :logger, level: :info
-#
-
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
-#     import_config "#{Mix.env}.exs"
+config :ueberauth, Ueberauth.Strategy.Microsoft.OAuth,
+  client_id: "client_id",
+  client_secret: "client_secret"

--- a/lib/ueberauth/strategy/microsoft/oauth.ex
+++ b/lib/ueberauth/strategy/microsoft/oauth.ex
@@ -13,6 +13,7 @@ defmodule Ueberauth.Strategy.Microsoft.OAuth do
     |> defaults()
     |> Keyword.merge(config)
     |> Keyword.merge(opts)
+    |> generate_secret()
     |> Client.new()
     |> OAuth2.Client.put_serializer("application/json", json_library)
   end
@@ -51,5 +52,15 @@ defmodule Ueberauth.Strategy.Microsoft.OAuth do
       authorize_url: "https://login.microsoftonline.com/#{tenant_id}/oauth2/v2.0/authorize",
       token_url: "https://login.microsoftonline.com/#{tenant_id}/oauth2/v2.0/token"
     ]
+  end
+
+  defp generate_secret(opts) do
+    if is_tuple(opts[:client_secret]) do
+      {module, fun} = opts[:client_secret]
+      secret = apply(module, fun, [opts])
+      Keyword.put(opts, :client_secret, secret)
+    else
+      opts
+    end
   end
 end

--- a/test/strategy/microsoft/oauth_test.exs
+++ b/test/strategy/microsoft/oauth_test.exs
@@ -1,0 +1,21 @@
+defmodule Ueberauth.Strategy.Microsoft.OAuthTest do
+  use ExUnit.Case, async: true
+
+  alias Ueberauth.Strategy.Microsoft.OAuth
+
+  defmodule MyApp.Microsoft do
+    def client_secret(_opts), do: "custom_client_secret"
+  end
+
+  describe "client/1" do
+    test "uses client secret in the config when it is not a tuple" do
+      assert %OAuth2.Client{client_secret: "client_secret"} = OAuth.client()
+    end
+
+    test "generates client secret when it is using a tuple config" do
+      options = [client_secret: {MyApp.Microsoft, :client_secret}]
+      assert %OAuth2.Client{client_secret: "custom_client_secret"} = OAuth.client(options)
+    end
+  end
+end
+


### PR DESCRIPTION
Similar to what was done in: https://github.com/ueberauth/ueberauth_google/pull/101

Add the possibility to get the client secret from a module in order to rotate the secret at least every 6 months (which is a the Microsoft recommendation) without the need to be changing the config or env var and restart the application. Similar to the implementation of ueberauth_apple: https://github.com/ueberauth/ueberauth_apple/blob/main/guides/getting-started.md#generating-the-client-secret

Configuration would look like this:
```elixir
config :ueberauth, Ueberauth.Strategy.Microsoft.OAuth,
  client_id: System.get_env("MICROSOFT_CLIENT_ID"),
  client_secret: {MyApp.Microsoft, :client_secret}
```

and then:
```elixir
defmodule MyApp.Microsoft
  @spec client_secret(config :: keyword) :: String.t()
  def client_secret(_config \\ []) do
    # Get client secret from db, cache or any other custom implementation.
  end
end
```

This does not affect to the current implementation, it is backwards compatible.
What do you think? @swelham 