### PR TITLE
Add support to lc param in authorization URL

### DIFF
--- a/lib/ueberauth/strategy/microsoft.ex
+++ b/lib/ueberauth/strategy/microsoft.ex
@@ -18,6 +18,7 @@ defmodule Ueberauth.Strategy.Microsoft do
       [scope: scopes, prompt: prompt]
       |> with_scopes(:extra_scopes, conn)
       |> with_state_param(conn)
+      |> with_param(:lc, conn)
 
     opts = oauth_client_options_from_conn(conn)
     redirect!(conn, Ueberauth.Strategy.Microsoft.OAuth.authorize_url!(params, opts))
@@ -153,5 +154,9 @@ defmodule Ueberauth.Strategy.Microsoft do
     conn
     |> options
     |> Keyword.get(key, default)
+  end
+
+  defp with_param(opts, key, conn) do
+    if value = conn.params[to_string(key)], do: Keyword.put(opts, key, value), else: opts
   end
 end

--- a/test/strategy/microsoft_test.exs
+++ b/test/strategy/microsoft_test.exs
@@ -1,0 +1,13 @@
+defmodule Ueberauth.Strategy.MicrosoftTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  test "lc param is present in the redirect uri" do
+    conn = conn(:get, "/auth/microsoft", %{lc: 10})
+    routes = Ueberauth.init()
+    resp = Ueberauth.call(conn, routes)
+    assert [location] = get_resp_header(resp, "location")
+    redirect_uri = URI.parse(location)
+    assert Plug.Conn.Query.decode(redirect_uri.query)["lc"] == "10"
+  end
+end


### PR DESCRIPTION
In order to change the locale in the Microsoft IDP interface, the param `lc` have to be passed in the authorization url.
List of supported locales: https://ss64.com/locale.html

Example URL:
```
https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=client_id&lc=10&prompt=&redirect_uri=http%3A%2F%2Fwww.example.com%2Fauth%2Fmicrosoft%2Fcallback&response_type=code&scope=https%3A%2F%2Fgraph.microsoft.com%2Fuser.read+openid+email+offline_access&state=4aLMsU9-69Hafb0QJ0AMCSQM
```

What do you think? @swelham 